### PR TITLE
Update login form name

### DIFF
--- a/pycaruna/authenticator.py
+++ b/pycaruna/authenticator.py
@@ -38,7 +38,7 @@ class Authenticator:
         # JavaScript.
         c = r.content
         soup = BeautifulSoup(c, 'lxml')
-        action = "/wicket/page?3-1.IBehaviorListener.0-userIDPanel-usernameLogin-loginWithUserID"
+        action = "/wicket/page?3-1.0-userIDPanel-usernameLogin-loginWithUserID"
 
         # Build form variables (all hidden variables must always be included)
         svars = utils.get_hidden_form_vars(soup)


### PR DESCRIPTION
Caruna changed the login form name which broke the authentication flow.

This fix is developed by Kimmo Linna in commit a1200f4 in the https://github.com/kimmolinna/pycaruna repository so I am just "cherry-picking" it here.